### PR TITLE
Re-Export Tracing Types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
-{
-    "rust-analyzer.cargo.features": "all",
-    //"rust-analyzer.cargo.target": "wasm32-unknown-unknown",
-}
+// {
+//     "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+// }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-logger"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A logging utility to provide a standard interface whether you're targetting web desktop, fullstack, and more."
 authors = ["DogeDark"]
@@ -14,11 +14,19 @@ categories = ["development-tools::debugging"]
 
 [dependencies]
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry", "std"] }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = [
+    "registry",
+    "std",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tracing-wasm = "0.2.1"
 console_error_panic_hook = "0.1.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = [
+    "fmt",
+] }
+
+[dev-dependencies]
+dioxus = { version = "0.5", features = ["desktop"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>📡 Dioxus Logger 🛰️</h1>
-  <p><strong>A logging utility to provide a standard interface whether you're targetting web desktop, fullstack, and more.</strong></p>
+  <p><strong>A logging utility to provide a standard interface whether you're targetting web, desktop, fullstack, and more.</strong></p>
 </div>
 
 <div align="center">
@@ -28,7 +28,7 @@
 
 ```rust
 use dioxus::prelude::*;
-use tracing::{Level, info};
+use dioxus_logger::{Level, info};
  
 fn main() {
   dioxus_logger::init(Level::INFO).expect("logger failed to init");

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ```rust
 use dioxus::prelude::*;
-use dioxus_logger::{Level, info};
+use dioxus_logger::tracing::{Level, info};
  
 fn main() {
   dioxus_logger::init(Level::INFO).expect("logger failed to init");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,13 @@ pub use tracing;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use dioxus::prelude::*;
 /// use dioxus_logger::tracing::{Level, info};
 ///
 /// fn main() {
 ///     dioxus_logger::init(Level::INFO).expect("logger failed to init");
-///     // launch app:
-///     // e.g. launch(App);
+///     launch(App);
 /// }
 ///
 /// #[component]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,27 @@
-use tracing::{
-    subscriber::{set_global_default, SetGlobalDefaultError}, Level,
+use tracing::subscriber::{set_global_default, SetGlobalDefaultError};
+
+pub use tracing::{
+    debug, debug_span, error, error_span, info, info_span, span, trace, trace_span, warn,
+    warn_span, Level,
 };
 
 /// Initialize `dioxus-logger` with a specified max filter.
 /// Generally it is best to initialize the logger before launching your Dioxus app.
 /// Works on Web, Desktop, Fullstack, and Liveview.
-/// 
+///
 /// # Example
-/// 
-/// ```rust,ignore
+///
+/// ```rust
 /// use dioxus::prelude::*;
-/// use tracing::{Level, info};
-/// 
+/// use dioxus_logger::{Level, info};
+///
 /// fn main() {
 ///     dioxus_logger::init(Level::INFO).expect("logger failed to init");
-///     launch(App);
+///     // launch app:
+///     // e.g. launch(App);
 /// }
+///
 /// 
-/// #[component]
 /// fn App() -> Element {
 ///     info!("App rendered");
 ///     rsx! {
@@ -31,7 +35,9 @@ pub fn init(level: Level) -> Result<(), SetGlobalDefaultError> {
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::Registry;
 
-        let layer_config = tracing_wasm::WASMLayerConfigBuilder::new().set_max_level(level).build();
+        let layer_config = tracing_wasm::WASMLayerConfigBuilder::new()
+            .set_max_level(level)
+            .build();
         let layer = tracing_wasm::WASMLayer::new(layer_config);
         let reg = Registry::default().with(layer);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-use tracing::subscriber::{set_global_default, SetGlobalDefaultError};
-
-pub use tracing::{
-    debug, debug_span, error, error_span, info, info_span, span, trace, trace_span, warn,
-    warn_span, Level,
+use tracing::{
+    subscriber::{set_global_default, SetGlobalDefaultError},
+    Level,
 };
+
+pub use tracing;
 
 /// Initialize `dioxus-logger` with a specified max filter.
 /// Generally it is best to initialize the logger before launching your Dioxus app.
@@ -13,7 +13,7 @@ pub use tracing::{
 ///
 /// ```rust
 /// use dioxus::prelude::*;
-/// use dioxus_logger::{Level, info};
+/// use dioxus_logger::tracing::{Level, info};
 ///
 /// fn main() {
 ///     dioxus_logger::init(Level::INFO).expect("logger failed to init");
@@ -21,7 +21,7 @@ pub use tracing::{
 ///     // e.g. launch(App);
 /// }
 ///
-///
+/// #[component]
 /// fn App() -> Element {
 ///     info!("App rendered");
 ///     rsx! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use tracing::{
 ///     // e.g. launch(App);
 /// }
 ///
-/// 
+///
 /// fn App() -> Element {
 ///     info!("App rendered");
 ///     rsx! {


### PR DESCRIPTION
Re-exports the most used tracing types such as logging macros and spans.
